### PR TITLE
AddressMapping: precompute log2 values to increase performance

### DIFF
--- a/AddressMapping.cpp
+++ b/AddressMapping.cpp
@@ -36,15 +36,15 @@ namespace DRAMSim
 void addressMapping(uint64_t physicalAddress, unsigned &newTransactionChan, unsigned &newTransactionRank, unsigned &newTransactionBank, unsigned &newTransactionRow, unsigned &newTransactionColumn)
 {
 	uint64_t tempA, tempB;
-	unsigned transactionSize = (JEDEC_DATA_BUS_BITS/8)*BL; 
+	unsigned transactionSize = TRANSACTION_SIZE;
 	uint64_t transactionMask =  transactionSize - 1; //ex: (64 bit bus width) x (8 Burst Length) - 1 = 64 bytes - 1 = 63 = 0x3f mask
-	unsigned channelBitWidth = dramsim_log2(NUM_CHANS);
-	unsigned	rankBitWidth = dramsim_log2(NUM_RANKS);
-	unsigned	bankBitWidth = dramsim_log2(NUM_BANKS);
-	unsigned	rowBitWidth = dramsim_log2(NUM_ROWS);
-	unsigned	colBitWidth = dramsim_log2(NUM_COLS);
+	unsigned channelBitWidth = NUM_CHANS_LOG;
+	unsigned rankBitWidth = NUM_RANKS_LOG;
+	unsigned bankBitWidth = NUM_BANKS_LOG;
+	unsigned rowBitWidth = NUM_ROWS_LOG;
+	unsigned colBitWidth = NUM_COLS_LOG;
 	// this forces the alignment to the width of a single burst (64 bits = 8 bytes = 3 address bits for DDR parts)
-	unsigned	byteOffsetWidth = dramsim_log2((JEDEC_DATA_BUS_BITS/8));
+	unsigned byteOffsetWidth = BYTE_OFFSET_WIDTH;
 	// Since we're assuming that a request is for BL*BUS_WIDTH, the bottom bits
 	// of this address *should* be all zeros if it's not, issue a warning
 
@@ -74,7 +74,7 @@ void addressMapping(uint64_t physicalAddress, unsigned &newTransactionChan, unsi
 	// from the bottom bits of the column 
 	// 
 	// For example: cowLowBits = log2(64bytes) - 3 bits = 3 bits 
-	unsigned colLowBitWidth = dramsim_log2(transactionSize) - byteOffsetWidth;
+	unsigned colLowBitWidth = COL_LOW_BIT_WIDTH;
 
 	physicalAddress >>= colLowBitWidth;
 	unsigned colHighBitWidth = colBitWidth - colLowBitWidth; 

--- a/IniReader.cpp
+++ b/IniReader.cpp
@@ -44,10 +44,18 @@ using namespace std;
 
 uint64_t TOTAL_STORAGE;
 unsigned NUM_BANKS;
+unsigned NUM_BANKS_LOG;
 unsigned NUM_CHANS;
+unsigned NUM_CHANS_LOG;
 unsigned NUM_ROWS;
+unsigned NUM_ROWS_LOG;
 unsigned NUM_COLS;
+unsigned NUM_COLS_LOG;
 unsigned DEVICE_WIDTH;
+unsigned BYTE_OFFSET_WIDTH;
+unsigned TRANSACTION_SIZE;
+unsigned THROW_AWAY_BITS;
+unsigned COL_LOW_BIT_WIDTH;
 
 unsigned REFRESH_PERIOD;
 float tCK;
@@ -417,6 +425,15 @@ void IniReader::ReadIniFile(string filename, bool isSystemFile)
 		ERROR ("Unable to load ini file "<<filename);
 		abort();
 	}
+	/* precompute frequently used values */
+	NUM_BANKS_LOG		= dramsim_log2(NUM_BANKS);
+	NUM_CHANS_LOG		= dramsim_log2(NUM_CHANS);
+	NUM_ROWS_LOG		= dramsim_log2(NUM_ROWS);
+	NUM_COLS_LOG		= dramsim_log2(NUM_COLS);
+	BYTE_OFFSET_WIDTH	= dramsim_log2(JEDEC_DATA_BUS_BITS / 8);
+	TRANSACTION_SIZE	= JEDEC_DATA_BUS_BITS / 8 * BL;
+	THROW_AWAY_BITS		= dramsim_log2(TRANSACTION_SIZE);
+	COL_LOW_BIT_WIDTH	= THROW_AWAY_BITS - BYTE_OFFSET_WIDTH;
 }
 
 void IniReader::OverrideKeys(const OverrideMap *map)

--- a/MemorySystem.cpp
+++ b/MemorySystem.cpp
@@ -47,6 +47,7 @@ ofstream cmd_verify_out; //used in Rank.cpp and MemoryController.cpp if VERIFICA
 
 unsigned NUM_DEVICES;
 unsigned NUM_RANKS;
+unsigned NUM_RANKS_LOG;
 
 namespace DRAMSim {
 
@@ -115,6 +116,7 @@ MemorySystem::MemorySystem(unsigned id, unsigned int megsOfMemory, CSVWriter &cs
 	if (megsOfMemory != 0)
 	{
 		NUM_RANKS = megsOfMemory / megsOfStoragePerRank;
+		NUM_RANKS_LOG = dramsim_log2(NUM_RANKS);
 		if (NUM_RANKS == 0)
 		{
 			PRINT("WARNING: Cannot create memory system with "<<megsOfMemory<<"MB, defaulting to minimum size of "<<megsOfStoragePerRank<<"MB");

--- a/SystemConfiguration.h
+++ b/SystemConfiguration.h
@@ -73,11 +73,20 @@ extern bool VIS_FILE_OUTPUT;
 
 extern uint64_t TOTAL_STORAGE;
 extern unsigned NUM_BANKS;
+extern unsigned NUM_BANKS_LOG;
 extern unsigned NUM_RANKS;
+extern unsigned NUM_RANKS_LOG;
 extern unsigned NUM_CHANS;
+extern unsigned NUM_CHANS_LOG;
 extern unsigned NUM_ROWS;
+extern unsigned NUM_ROWS_LOG;
 extern unsigned NUM_COLS;
+extern unsigned NUM_COLS_LOG;
 extern unsigned DEVICE_WIDTH;
+extern unsigned BYTE_OFFSET_WIDTH;
+extern unsigned TRANSACTION_SIZE;
+extern unsigned THROW_AWAY_BITS;
+extern unsigned COL_LOW_BIT_WIDTH;
 
 //in nanoseconds
 extern unsigned REFRESH_PERIOD;

--- a/TraceBasedSim.cpp
+++ b/TraceBasedSim.cpp
@@ -328,7 +328,7 @@ void alignTransactionAddress(Transaction &trans)
 {
 	// zero out the low order bits which correspond to the size of a transaction
 
-	unsigned throwAwayBits = dramsim_log2((BL*JEDEC_DATA_BUS_BITS/8));
+	unsigned throwAwayBits = THROW_AWAY_BITS;
 
 	trans.address >>= throwAwayBits;
 	trans.address <<= throwAwayBits;


### PR DESCRIPTION
The log2 function is slow. But this is not the issue; calling it
in the hot path is the real (performance) issue.

The appended precomputes frequently-used values to avoid computing
them in the hot path. This results in a lot less instructions
executed, and a significant increase in performance.

This closes issue #46: simulation performance.

Before the patch:

 Performance counter stats for './DRAMSim -t traces/k6_aoe_02_short.trc -d ini/DDR3_micron_16M_8B_x8_sg15.ini -s system.ini.example -c 10000000' (3 runs):

```
  20507.071226 task-clock                #    1.000 CPUs utilized            ( +-  1.09% )
            61 context-switches          #    0.000 M/sec                    ( +-  0.95% )
             0 CPU-migrations            #    0.000 M/sec
           468 page-faults               #    0.000 M/sec
58,683,786,689 cycles                    #    2.862 GHz                      ( +-  0.69% ) [83.33%]
13,434,240,170 stalled-cycles-frontend   #   22.89% frontend cycles idle     ( +-  2.80% ) [83.34%]
 5,915,970,070 stalled-cycles-backend    #   10.08% backend  cycles idle     ( +-  4.87% ) [66.67%]
```

   120,280,797,002 instructions              #    2.05  insns per cycle
                                             #    0.11  stalled cycles per insn  ( +-  0.00% ) [83.33%]
    23,425,385,282 branches                  # 1142.308 M/sec                    ( +-  0.01% ) [83.34%]
       226,637,631 branch-misses             #    0.97% of all branches          ( +-  1.03% ) [83.33%]

```
  20.514895432 seconds time elapsed                                          ( +-  1.09% )
```

After:

 Performance counter stats for './DRAMSim -t traces/k6_aoe_02_short.trc -d ini/DDR3_micron_16M_8B_x8_sg15.ini -s system.ini.example -c 10000000' (3 runs):

```
  15562.506598 task-clock                #    1.000 CPUs utilized            ( +-  0.72% )
            55 context-switches          #    0.000 M/sec
             0 CPU-migrations            #    0.000 M/sec                    ( +-100.00% )
           469 page-faults               #    0.000 M/sec                    ( +-  0.07% )
43,650,612,082 cycles                    #    2.805 GHz                      ( +-  0.58% ) [83.33%]
11,878,548,969 stalled-cycles-frontend   #   27.21% frontend cycles idle     ( +-  1.46% ) [83.33%]
 6,125,126,936 stalled-cycles-backend    #   14.03% backend  cycles idle     ( +-  3.74% ) [66.67%]
82,655,485,444 instructions              #    1.89  insns per cycle
                                         #    0.14  stalled cycles per insn  ( +-  0.01% ) [83.33%]
14,515,927,254 branches                  #  932.750 M/sec                    ( +-  0.02% ) [83.34%]
   235,566,078 branch-misses             #    1.62% of all branches          ( +-  1.87% ) [83.34%]

  15.568698124 seconds time elapsed                                          ( +-  0.72% )
```

Signed-off-by: Emilio G. Cota cota@braap.org
