### PR TITLE
DRAMSim: export Ini configuration getters

### DIFF
--- a/DRAMSim.h
+++ b/DRAMSim.h
@@ -56,6 +56,10 @@ namespace DRAMSim
 				TransactionCompleteCB *readDone,
 				TransactionCompleteCB *writeDone,
 				void (*reportPower)(double bgpower, double burstpower, double refreshpower, double actprepower));
+			int getIniBool(const std::string &field, bool *val);
+			int getIniUint(const std::string &field, unsigned int *val);
+			int getIniUint64(const std::string &field, uint64_t *val);
+			int getIniFloat(const std::string &field, float *val);
 	};
 	MultiChannelMemorySystem *getMemorySystemInstance(const string &dev, const string &sys, const string &pwd, const string &trc, unsigned megsOfMemory, std::string *visfilename=NULL);
 }

--- a/IniReader.cpp
+++ b/IniReader.cpp
@@ -463,6 +463,36 @@ bool IniReader::CheckIfAllSet()
 	}
 	return true;
 }
+
+/*
+ * There is probably a way of doing this with templates, but since
+ * we have the types defined as an enum, doing this with macros is trivial.
+ *
+ * Return value: 0 on success, -1 on error
+ */
+#define DEF_GETTER(_funcname, _type, _typename)				\
+	int _funcname(const std::string& field, _type *val)		\
+	{								\
+		int i;							\
+									\
+		for (i=0; configMap[i].variablePtr != NULL; i++)	\
+		{							\
+			if (field.compare(configMap[i].iniKey))		\
+				continue;				\
+			if (configMap[i].variableType != _typename)	\
+				return -1;				\
+			*val = *(_type *)configMap[i].variablePtr;	\
+			return 0;					\
+		}							\
+		return -1;						\
+	}
+
+/* TODO: getter for strings is missing. Probably not that useful though */
+DEF_GETTER(IniReader::getBool, bool, BOOL)
+DEF_GETTER(IniReader::getUint, unsigned int, UINT)
+DEF_GETTER(IniReader::getUint64, uint64_t, UINT64)
+DEF_GETTER(IniReader::getFloat, float, FLOAT)
+
 void IniReader::InitEnumsFromStrings()
 {
 	if (ADDRESS_MAPPING_SCHEME == "scheme1")

--- a/IniReader.h
+++ b/IniReader.h
@@ -74,6 +74,10 @@ public:
 	static void InitEnumsFromStrings();
 	static bool CheckIfAllSet();
 	static void WriteValuesOut(std::ofstream &visDataOut);
+	static int getBool(const std::string &field, bool *val);
+	static int getUint(const std::string &field, unsigned int *val);
+	static int getUint64(const std::string &field, uint64_t *val);
+	static int getFloat(const std::string &field, float *val);
 
 private:
 	static void WriteParams(std::ofstream &visDataOut, paramType t);

--- a/MultiChannelMemorySystem.cpp
+++ b/MultiChannelMemorySystem.cpp
@@ -497,6 +497,40 @@ void MultiChannelMemorySystem::RegisterCallbacks(
 		channels[i]->RegisterCallbacks(readDone, writeDone, reportPower); 
 	}
 }
+
+/*
+ * The getters below are useful to external simulators interfacing with DRAMSim
+ *
+ * Return value: 0 on success, -1 on error
+ */
+int MultiChannelMemorySystem::getIniBool(const std::string& field, bool *val)
+{
+	if (!IniReader::CheckIfAllSet())
+		exit(-1);
+	return IniReader::getBool(field, val);
+}
+
+int MultiChannelMemorySystem::getIniUint(const std::string& field, unsigned int *val)
+{
+	if (!IniReader::CheckIfAllSet())
+		exit(-1);
+	return IniReader::getUint(field, val);
+}
+
+int MultiChannelMemorySystem::getIniUint64(const std::string& field, uint64_t *val)
+{
+	if (!IniReader::CheckIfAllSet())
+		exit(-1);
+	return IniReader::getUint64(field, val);
+}
+
+int MultiChannelMemorySystem::getIniFloat(const std::string& field, float *val)
+{
+	if (!IniReader::CheckIfAllSet())
+		exit(-1);
+	return IniReader::getFloat(field, val);
+}
+
 namespace DRAMSim {
 MultiChannelMemorySystem *getMemorySystemInstance(const string &dev, const string &sys, const string &pwd, const string &trc, unsigned megsOfMemory, string *visfilename) 
 {

--- a/MultiChannelMemorySystem.h
+++ b/MultiChannelMemorySystem.h
@@ -57,6 +57,10 @@ class MultiChannelMemorySystem : public SimulatorObject
 				TransactionCompleteCB *readDone,
 				TransactionCompleteCB *writeDone,
 				void (*reportPower)(double bgpower, double burstpower, double refreshpower, double actprepower));
+			int getIniBool(const std::string &field, bool *val);
+			int getIniUint(const std::string &field, unsigned int *val);
+			int getIniUint64(const std::string &field, uint64_t *val);
+			int getIniFloat(const std::string &field, float *val);
 
 	void InitOutputFiles(string tracefilename);
 	void setCPUClockSpeed(uint64_t cpuClkFreqHz);


### PR DESCRIPTION
External simulators have no way of fetching configuration values
from the Ini file. This is a limitation that forces these simulators
to directly read the config file (e.g. gem5 with its dramsim_wrapper
class), which is a bad idea because a) the file is read twice
b) the DRAMSim overrides and sanity checks are ignored.

To avoid these limitations, the appended exports getters for
configuration values. These values are read directly from the
internal data structures, so that the configuration file is
only read once, as it should be.

Signed-off-by: Emilio G. Cota cota@braap.org
